### PR TITLE
Bugfix for find_best_stream and sws.Context.get

### DIFF
--- a/av.zig
+++ b/av.zig
@@ -901,7 +901,7 @@ pub const FormatContext = extern struct {
         /// or -1 if none
         related_stream: c_int,
     ) Error!struct { c_uint, *const Codec } {
-        var decoder: ?*Codec = undefined;
+        var decoder: ?*const Codec = undefined;
         const n = try wrap(av_find_best_stream(ic, media_type, wanted_stream_nb, related_stream, &decoder, 0));
         return .{ n, decoder.? };
     }

--- a/av.zig
+++ b/av.zig
@@ -3744,7 +3744,7 @@ pub const sws = struct {
 
         /// Allocate and return an sws.Context. You need it to perform
         /// scaling/conversion operations using sws.Context.scale().
-        pub fn get(srcW: c_int, srcH: c_int, srcFormat: PixelFormat, dstW: c_int, dstH: c_int, dstFormat: PixelFormat, flags: Flags, srcFilter: ?*sws.Filter, dstFilter: ?*sws.Filter, param: ?[*]const f64) error{OutOfMemory}!void {
+        pub fn get(srcW: c_int, srcH: c_int, srcFormat: PixelFormat, dstW: c_int, dstH: c_int, dstFormat: PixelFormat, flags: Flags, srcFilter: ?*sws.Filter, dstFilter: ?*sws.Filter, param: ?[*]const f64) error{OutOfMemory}!*Context {
             return sws_getContext(srcW, srcH, srcFormat, dstW, dstH, dstFormat, flags, srcFilter, dstFilter, param) orelse error.OutOfMemory;
         }
 


### PR DESCRIPTION
The first commit solves a compile error when using  `FormatContext.find_best_stream`.

```
expected type '?*?*const av.Codec', found '*?*av.Codec')
```

The second commit fixs a bug where `sws.Context.get` returns nothing but it should return a point to the allocated context.