### PR TITLE
Update README to use `exe.root_module.linkLibrary` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Choose one:
 - Just link ffmpeg:
 
   ```zig
-  exe.linkLibrary(ffmpeg_dep.artifact("ffmpeg"));
+  exe.root_module.linkLibrary(ffmpeg_dep.artifact("ffmpeg"));
   ```
 - Add zig bindings with `@import("ffmpeg")`
   


### PR DESCRIPTION
Updates the build.zig usage examples to use the current Zig build system API (`exe.root_module.linkLibrary()`) instead of the older `exe.linkLibrary()`.