### PR TITLE
Gets libogg and libvorbis from allyourcodebase

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -32,7 +32,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    const libogg_dep = b.dependency("libogg", .{
+    const libogg_dep = libvorbis_dep.builder.dependency("libogg", .{
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -30,12 +30,8 @@
             .hash = "libmp3lame-3.100.1-6-67wlF1qxEwBuTD-o_MpTmmvE59MXo4cPfuki50pcdVgx",
         },
         .libvorbis = .{
-            .url = "https://github.com/andrewrk/libvorbis/archive/b13b88185e157a7d532bddf1cfb9694f1d7f8d7e.tar.gz",
-            .hash = "libvorbis-1.3.8-6-gL_KIwoQJAApeDIAxmsSvMot601UDuCfYY-vTd3qdwhT",
-        },
-        .libogg = .{
-            .url = "https://github.com/andrewrk/libogg/archive/aa85a1820fd544fac7b924c458bf164d0fd1e198.tar.gz",
-            .hash = "libogg-1.3.6-4-ZBKq7YwWAgCGiqoGpk1Hj1IuaYf84q9EV-tns7cuFjTq",
+            .url = "git+https://codeberg.org/allyourcodebase/libvorbis#410cdd66bd207aef0d248475dbed3cf7ca1eb9d4",
+            .hash = "libvorbis-0.0.0+1.3.7-1wt9j_QPAADVure94TG4ecBMLD8eIAzWd6ZxVOmBBPCu",
         },
 
         // This is used to compile some assembly files into object files for x86.


### PR DESCRIPTION
Switches libogg and libvorbis to pristine tarball versions I just pushed to the Codeberg AllYourCodebase organization.

***

I dropped the dependency on libogg from `build.zig.zon` since it's already brought in via libvorbis. We still link to libogg explicitly, as we did previously, since this brings in the headers. I'm not sure that I understand why this is necessary, I would have expected them to be brought along via the transitive dependency.

I tested this change by building ffmpeg and making sure it succeeded. I don't currently depend on ffmpeg (just needed libogg and libvorbis for something else and figured I may as well update this project) so I didn't do any testing outside of verifying that it still builds.